### PR TITLE
Add support for max.poll.records setting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ lazy val tests = (project in file("tests")).
     publishLocal := {},
     publish := {},
     libraryDependencies ++= Seq(
-      "org.apache.kafka" % "kafka-clients" % "0.9.0.1",
+      "org.apache.kafka" % "kafka-clients" % "0.10.1.0",
       "org.scalactic" %% "scalactic" % "2.2.6" % "it,test",
       "org.scalamock" %% "scalamock-scalatest-support" % "3.2.2" % "it,test",
       "org.scalatest" %% "scalatest" % "2.2.6" % "it,test",
@@ -83,7 +83,7 @@ lazy val main = (project in file("main")).
   settings(
     name := "kafka-consumer",
     libraryDependencies ++= Seq(
-      "org.apache.kafka" % "kafka-clients" % "0.9.0.1",
+      "org.apache.kafka" % "kafka-clients" % "0.10.1.0",
       "org.slf4j" % "slf4j-api" % "1.7.12")
   )
 

--- a/main/src/main/scala/com/pagerduty/kafkaconsumer/SimpleKafkaConsumer.scala
+++ b/main/src/main/scala/com/pagerduty/kafkaconsumer/SimpleKafkaConsumer.scala
@@ -20,7 +20,7 @@ import scala.util.control.NonFatal
  * `processRecords(...)` method:
  * {{{
  * import scala.collection.JavaConversions._
- * 
+ *
  * class MyConsumer extends SimpleKafkaConsumer(
  *   myTopic, properties)
  * {
@@ -322,7 +322,11 @@ object SimpleKafkaConsumer {
   val commitOffsetTimeout: Duration = 5 seconds
 
   /** Helper to create basic properties */
-  def makeProps(bootstrapServer: String, consumerGroup: String): Properties = {
+  def makeProps(
+    bootstrapServer: String,
+    consumerGroup: String,
+    maxPollRecords: Option[Int] = None
+  ): Properties = {
     val props = new Properties()
     props.put("group.id", consumerGroup)
     props.put("bootstrap.servers", bootstrapServer)
@@ -330,6 +334,9 @@ object SimpleKafkaConsumer {
     // - if you consume a single topic, you'll save this times partitions in memory which is
     // usually a big "meh".
     props.put("max.partition.fetch.bytes", ((4 * 1024 * 1024) + 50000).toString)
+
+    maxPollRecords.foreach { (v: Int) => props.put("max.poll.records", v.toString) }
+
     props
   }
 }

--- a/tests/src/it/scala/com/pagerduty/kafkaconsumer/SimpleKafkaConsumerSpec.scala
+++ b/tests/src/it/scala/com/pagerduty/kafkaconsumer/SimpleKafkaConsumerSpec.scala
@@ -124,6 +124,19 @@ class SimpleKafkaConsumerSpec
       Await.result(consumer.shutdown(), 10.seconds)
       consumer.partitionCount shouldBe Some(1)
     }
+
+    "support max.poll.records" in {
+      val consumer = new TestConsumer(topic, maxPollRecords = Option(4))
+      consumer.start()
+
+      val ids: Seq[Long] = makeMessageIdSeq(10)
+      testProducer.sendTestMessages(ids)
+
+      consumer.awaitTermination()
+
+      val expectedIdGroups: Seq[Seq[Long]] = ids.grouped(4).toSeq
+      consumer.processedKeyGroups shouldBe expectedIdGroups
+    }
   }
 
   def makeMessageIdSeq(count: Int): Seq[Long] = {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.2"
+version in ThisBuild := "0.4.0"


### PR DESCRIPTION
A Kafka 0.10 setting

TODO:
- [x] add setting option
- [x] update kafka client dependency version
- [x] bump version
- [x] integration test
- [x] update travis test to use kafka 0.10
