### PR TITLE
Add a PartitionedKafkaConsumer

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,4 @@
+verticalMultilineAtDefinitionSite = true
+maxColumn = 120
+align.openParenCallSite = false
+danglingParentheses = true

--- a/.travis.release.sh
+++ b/.travis.release.sh
@@ -25,7 +25,7 @@ GIT_TAG=v$RELEASE_VER
 
 echo "Conditionally publishing release and cutting git tag..."
 test "${TRAVIS_PULL_REQUEST}" = 'false' &&
-test "${TRAVIS_JDK_VERSION}" = 'openjdk7' &&
+test "${TRAVIS_JDK_VERSION}" = 'oraclejdk8' &&
 sbt ++${TRAVIS_SCALA_VERSION} publish &&
 git tag -a $GIT_TAG -m "Release version $RELEASE_VER" &&
 git push origin $GIT_TAG

--- a/.travis.release.sh
+++ b/.travis.release.sh
@@ -23,9 +23,18 @@ echo "Parsing release version..."
 RELEASE_VER=$(cat version.sbt | grep -o '".*"' | tr -d '"')
 GIT_TAG=v$RELEASE_VER
 
+# we have to do some manual version setting because SBT doesn't seem to understand that partitioned should not be compiled for 2.10
 echo "Conditionally publishing release and cutting git tag..."
 test "${TRAVIS_PULL_REQUEST}" = 'false' &&
 test "${TRAVIS_JDK_VERSION}" = 'oraclejdk8' &&
-sbt ++${TRAVIS_SCALA_VERSION} publish &&
+test "${TRAVIS_SCALA_VERSION}" = '2.11.11' &&
+sbt ++2.10.6 testSupport/publish &&
+sbt ++2.11.11 testSupport/publish &&
+sbt ++2.12.2 testSupport/publish &&
+sbt ++2.10.6 main/publish &&
+sbt ++2.11.11 main/publish &&
+sbt ++2.12.2 main/publish &&
+sbt ++2.11.11 partitioned/publish &&
+sbt ++2.12.2 partitioned/publish &&
 git tag -a $GIT_TAG -m "Release version $RELEASE_VER" &&
 git push origin $GIT_TAG

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ scala:
 - 2.10.6
 - 2.11.7
 jdk:
-- openjdk7
+- oraclejdk8
 sudo: false
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ branches:
   - master
 language: scala
 scala:
-- 2.10.6
-- 2.11.7
+- 2.11.11
+- 2.12.2
 jdk:
 - oraclejdk8
 sudo: false

--- a/README.md
+++ b/README.md
@@ -12,21 +12,36 @@ integration tests.
 
 ## Installation
 
-This library is published to PagerDuty Bintray OSS Maven repository:
+This library is published as a number of different artifacts to the PagerDuty Bintray OSS Maven repository:
 
 ```scala
 resolvers += "bintray-pagerduty-oss-maven" at "https://dl.bintray.com/pagerduty/oss-maven"
 ```
 
-Adding the dependency to your SBT build file:
+Currently, there are two different consumers available:
 
-```scala
-libraryDependencies += "com.pagerduty" %% "kafka-consumer" % "0.3.2"
-```
+ - [`SimpleKafkaConsumer`](main/src/main/scala/com/pagerduty/kafkaconsumer/SimpleKafkaConsumer.scala) - As the name suggests, 
+   this consumer is very simple to use and has few dependencies. It is available as follows:
+   
+   ```scala
+   libraryDependencies += "com.pagerduty" %% "kafka-consumer" % "<version>"
+   ```   
+   
+ - [`PartitionedKafkaConsumer`](partitioned/src/main/scala/com/pagerduty/kafkaconsumer/PartitionedKafkaConsumer.scala) - 
+   This consumer improves on `SimpleKafkaConsumer` at the expense of an additional dependency
+   (Akka Streams) and no support for 2.10. This consumer processes and commits Kafka messages for each assigned partition
+   independently and in parallel. Therefore, this consumer is both faster and more tolerant of transient processing failures.
+   It is available as follows:
+   
+   ```scala
+   libraryDependencies += "com.pagerduty" %% "kafka-consumer-partitioned" % "<version>"
+   ```   
 
 ## Usage
 
-Create a new `SimpleKafkaConsumer` and get cranking. Usually you need three items to get a default
+This library is published as a number of separate artifacts
+
+Create a new `SimpleKafkaConsumer` or `PartitionedKafkaConsumer` and get cranking. Usually you need three items to get a default
 consumer up and running:
 
 - The topic the consumer works on (constructor argument)

--- a/build.sbt
+++ b/build.sbt
@@ -74,11 +74,11 @@ lazy val testSupport = (project in file("test-support"))
   .settings(publishSettings: _*)
   .settings(
     name := "kafka-consumer-test-support",
-    crossScalaVersions := Seq("2.10.6", "2.11.11"),
+    crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.2"),
     libraryDependencies ++= Seq(
-      "org.scalactic" %% "scalactic" % "2.2.6",
-      "org.scalamock" %% "scalamock-scalatest-support" % "3.2.2",
-      "org.scalatest" %% "scalatest" % "2.2.6",
+      "org.scalactic" %% "scalactic" % "3.0.1",
+      "org.scalamock" %% "scalamock-scalatest-support" % "3.5.0",
+      "org.scalatest" %% "scalatest" % "3.0.1",
       "org.slf4j" % "slf4j-simple" % "1.7.12"
     )
   )
@@ -88,7 +88,7 @@ lazy val main = (project in file("main"))
   .settings(publishSettings: _*)
   .settings(
     name := "kafka-consumer",
-    crossScalaVersions := Seq("2.10.6", "2.11.11"),
+    crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.2"),
     libraryDependencies ++= Seq(
       "org.apache.kafka" % "kafka-clients" % KafkaClientVersion,
       "org.slf4j" % "slf4j-api" % "1.7.12"

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ lazy val publishSettings = Seq(
 
 lazy val sharedSettings = Seq(
   organization := "com.pagerduty",
-  scalaVersion := "2.10.6",
+  scalaVersion := "2.11.11",
   crossScalaVersions := Seq("2.10.6", "2.11.7")
 )
 
@@ -87,10 +87,25 @@ lazy val main = (project in file("main")).
       "org.slf4j" % "slf4j-api" % "1.7.12")
   )
 
+lazy val partitioned = (project in file("partitioned")).
+  settings(publishSettings: _*).
+  settings(
+    name := "kafka-consumer-partitioned",
+    organization := "com.pagerduty",
+    scalaVersion := "2.11.11",
+    crossScalaVersions := Seq("2.11.11", "2.12.2"),
+    libraryDependencies ++= Seq(
+      "com.typesafe.akka" %% "akka-stream" % "2.5.3",
+      "com.typesafe.akka" %% "akka-stream-kafka" % "0.16",
+      "org.slf4j" % "slf4j-api" % "1.7+",
+      "com.typesafe.akka" %% "akka-slf4j" % "2.4.18"
+    )
+  )
+
 lazy val root = Project(
   id = "root",
   base = file("."),
-  aggregate = Seq(tests, testSupport, main),
+  aggregate = Seq(tests, testSupport, main, partitioned),
   settings = Project.defaultSettings ++ Seq(
     publishLocal := {},
     publish := {},

--- a/build.sbt
+++ b/build.sbt
@@ -37,9 +37,13 @@ lazy val publishSettings = Seq(
       </developers>)
 )
 
+lazy val KafkaClientVersion = "0.10.1.1"
+
 lazy val sharedSettings = Seq(
   organization := "com.pagerduty",
-  scalaVersion := "2.11.11"
+  scalaVersion := "2.11.11",
+  // akka-stream-kafka wants a newer version, but works fine with the older client
+  dependencyOverrides += "org.apache.kafka" % "kafka-clients" % KafkaClientVersion
 )
 
 lazy val tests = (project in file("tests"))
@@ -55,7 +59,7 @@ lazy val tests = (project in file("tests"))
     publishLocal := {},
     publish := {},
     libraryDependencies ++= Seq(
-      "org.apache.kafka" % "kafka-clients" % "0.10.1.1",
+      "org.apache.kafka" % "kafka-clients" % KafkaClientVersion,
       "org.scalactic" %% "scalactic" % "2.2.6" % "it,test",
       "org.scalamock" %% "scalamock-scalatest-support" % "3.2.2" % "it,test",
       "org.scalatest" %% "scalatest" % "2.2.6" % "it,test",
@@ -86,7 +90,7 @@ lazy val main = (project in file("main"))
     name := "kafka-consumer",
     crossScalaVersions := Seq("2.10.6", "2.11.11"),
     libraryDependencies ++= Seq(
-      "org.apache.kafka" % "kafka-clients" % "0.10.1.1",
+      "org.apache.kafka" % "kafka-clients" % KafkaClientVersion,
       "org.slf4j" % "slf4j-api" % "1.7.12"
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -39,14 +39,13 @@ lazy val publishSettings = Seq(
 
 lazy val sharedSettings = Seq(
   organization := "com.pagerduty",
-  scalaVersion := "2.11.11",
-  crossScalaVersions := Seq("2.10.6", "2.11.7")
+  scalaVersion := "2.11.11"
 )
 
 lazy val tests = (project in file("tests"))
   .configs(IntegrationTest)
   .settings(inConfig(IntegrationTest)(scalafmtSettings))
-  .dependsOn(main, testSupport)
+  .dependsOn(main, testSupport, partitioned)
   .settings(Defaults.itSettings: _*)
   .settings(sharedSettings: _*)
   .settings(
@@ -71,6 +70,7 @@ lazy val testSupport = (project in file("test-support"))
   .settings(publishSettings: _*)
   .settings(
     name := "kafka-consumer-test-support",
+    crossScalaVersions := Seq("2.10.6", "2.11.11"),
     libraryDependencies ++= Seq(
       "org.scalactic" %% "scalactic" % "2.2.6",
       "org.scalamock" %% "scalamock-scalatest-support" % "3.2.2",
@@ -84,6 +84,7 @@ lazy val main = (project in file("main"))
   .settings(publishSettings: _*)
   .settings(
     name := "kafka-consumer",
+    crossScalaVersions := Seq("2.10.6", "2.11.11"),
     libraryDependencies ++= Seq(
       "org.apache.kafka" % "kafka-clients" % "0.10.1.1",
       "org.slf4j" % "slf4j-api" % "1.7.12"
@@ -91,11 +92,10 @@ lazy val main = (project in file("main"))
   )
 
 lazy val partitioned = (project in file("partitioned"))
+  .settings(sharedSettings: _*)
   .settings(publishSettings: _*)
   .settings(
     name := "kafka-consumer-partitioned",
-    organization := "com.pagerduty",
-    scalaVersion := "2.11.11",
     crossScalaVersions := Seq("2.11.11", "2.12.2"),
     libraryDependencies ++= Seq(
       "com.typesafe.akka" %% "akka-stream" % "2.5.3",

--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,7 @@ lazy val publishSettings = Seq(
   bintrayRepository := "oss-maven",
   licenses += ("BSD New", url("https://opensource.org/licenses/BSD-3-Clause")),
   publishMavenStyle := true,
-  pomExtra := (
-    <url>https://github.com/PagerDuty/scala-kafka-consumer</url>
+  pomExtra := (<url>https://github.com/PagerDuty/scala-kafka-consumer</url>
       <scm>
         <url>git@github.com:PagerDuty/scala-kafka-consumer.git</url>
         <connection>scm:git:git@github.com:PagerDuty/scala-kafka-consumer.git</connection>
@@ -44,12 +43,13 @@ lazy val sharedSettings = Seq(
   crossScalaVersions := Seq("2.10.6", "2.11.7")
 )
 
-lazy val tests = (project in file("tests")).
-  configs(IntegrationTest).
-  dependsOn(main, testSupport).
-  settings(Defaults.itSettings: _*).
-  settings(sharedSettings: _*).
-  settings(
+lazy val tests = (project in file("tests"))
+  .configs(IntegrationTest)
+  .settings(inConfig(IntegrationTest)(scalafmtSettings))
+  .dependsOn(main, testSupport)
+  .settings(Defaults.itSettings: _*)
+  .settings(sharedSettings: _*)
+  .settings(
     name := "kafka-consumer-tests",
     publishArtifact in Compile := false,
     publishArtifact in Test := false,
@@ -61,35 +61,38 @@ lazy val tests = (project in file("tests")).
       "org.scalamock" %% "scalamock-scalatest-support" % "3.2.2" % "it,test",
       "org.scalatest" %% "scalatest" % "2.2.6" % "it,test",
       "org.slf4j" % "slf4j-api" % "1.7.12",
-      "org.slf4j" % "slf4j-simple" % "1.7.12" % "it,test")
+      "org.slf4j" % "slf4j-simple" % "1.7.12" % "it,test"
+    )
   )
 
-lazy val testSupport = (project in file("test-support")).
-  dependsOn(main).
-  settings(sharedSettings: _*).
-  settings(publishSettings: _*).
-  settings(
+lazy val testSupport = (project in file("test-support"))
+  .dependsOn(main)
+  .settings(sharedSettings: _*)
+  .settings(publishSettings: _*)
+  .settings(
     name := "kafka-consumer-test-support",
     libraryDependencies ++= Seq(
       "org.scalactic" %% "scalactic" % "2.2.6",
       "org.scalamock" %% "scalamock-scalatest-support" % "3.2.2",
       "org.scalatest" %% "scalatest" % "2.2.6",
-      "org.slf4j" % "slf4j-simple" % "1.7.12")
+      "org.slf4j" % "slf4j-simple" % "1.7.12"
+    )
   )
 
-lazy val main = (project in file("main")).
-  settings(sharedSettings: _*).
-  settings(publishSettings: _*).
-  settings(
+lazy val main = (project in file("main"))
+  .settings(sharedSettings: _*)
+  .settings(publishSettings: _*)
+  .settings(
     name := "kafka-consumer",
     libraryDependencies ++= Seq(
       "org.apache.kafka" % "kafka-clients" % "0.10.1.1",
-      "org.slf4j" % "slf4j-api" % "1.7.12")
+      "org.slf4j" % "slf4j-api" % "1.7.12"
+    )
   )
 
-lazy val partitioned = (project in file("partitioned")).
-  settings(publishSettings: _*).
-  settings(
+lazy val partitioned = (project in file("partitioned"))
+  .settings(publishSettings: _*)
+  .settings(
     name := "kafka-consumer-partitioned",
     organization := "com.pagerduty",
     scalaVersion := "2.11.11",
@@ -102,12 +105,12 @@ lazy val partitioned = (project in file("partitioned")).
     )
   )
 
-lazy val root = Project(
-  id = "root",
-  base = file("."),
-  aggregate = Seq(tests, testSupport, main, partitioned),
-  settings = Project.defaultSettings ++ Seq(
+lazy val root = (project in file("."))
+  .settings(
     publishLocal := {},
     publish := {},
-    publishArtifact := false)
+    publishArtifact := false
   )
+  .aggregate(tests, testSupport, main, partitioned)
+
+scalafmtOnCompile in ThisBuild := true

--- a/main/src/main/scala/com/pagerduty/kafkaconsumer/LoggingRebalanceListener.scala
+++ b/main/src/main/scala/com/pagerduty/kafkaconsumer/LoggingRebalanceListener.scala
@@ -7,11 +7,11 @@ import org.slf4j.Logger
 import scala.collection.JavaConversions._
 
 /**
- * LoggingRebalanceListener will log partition re-balancing events for selected topic.
- *
- * @param topic
- * @param log
- */
+  * LoggingRebalanceListener will log partition re-balancing events for selected topic.
+  *
+  * @param topic
+  * @param log
+  */
 class LoggingRebalanceListener(topic: String, log: Logger) extends ConsumerRebalanceListener {
   private var currentAssignment = Set.empty[TopicPartition]
 
@@ -37,9 +37,7 @@ class LoggingRebalanceListener(topic: String, log: Logger) extends ConsumerRebal
 
   protected def logNewAssignment(partitions: Set[TopicPartition]): Unit = {}
 
-  protected def getTopicPartitioningInfo(
-    partitions: Set[TopicPartition], maxLength: Option[Int] = None
-  ): String = {
+  protected def getTopicPartitioningInfo(partitions: Set[TopicPartition], maxLength: Option[Int] = None): String = {
     def shorten(string: String, length: Int) = {
       if (string.length > length) string.take(length - 3) + "..." else string
     }

--- a/main/src/main/scala/com/pagerduty/kafkaconsumer/SimpleKafkaConsumer.scala
+++ b/main/src/main/scala/com/pagerduty/kafkaconsumer/SimpleKafkaConsumer.scala
@@ -1,11 +1,11 @@
 package com.pagerduty.kafkaconsumer
 
 import java.util.Properties
-import java.util.concurrent.{ Executors, ThreadFactory, TimeoutException }
+import java.util.concurrent.{Executors, ThreadFactory, TimeoutException}
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.WakeupException
-import org.apache.kafka.common.serialization.{ Deserializer, StringDeserializer }
+import org.apache.kafka.common.serialization.{Deserializer, StringDeserializer}
 import org.slf4j.LoggerFactory
 import scala.collection.JavaConversions._
 import scala.concurrent.duration._
@@ -14,46 +14,46 @@ import scala.util.Random
 import scala.util.control.NonFatal
 
 /**
- * SimpleKafkaConsumer aims to abstract away low level Kafka polling and error handling details.
- *
- * All you have to do is extend this class and provide your own implementation of
- * `processRecords(...)` method:
- * {{{
- * import scala.collection.JavaConversions._
- *
- * class MyConsumer extends SimpleKafkaConsumer(
- *   myTopic, properties)
- * {
- *   override protected def processRecords(records: ConsumerRecords[String, String]): Unit = {
- *     for (record <- records) { println(record) }
- *   }
- * }
- * }}}
- *
- * After instantiation, call the `start()` to begin polling the configured Kafka broker.
- * Remember to call the `shutdown()` method in order to stop polling and release all the
- * assigned partitions.
- *
- * {{{
- *   val consumer = new MyConsumer
- *   consumer.start()
- *   ...
- *   consumer.shutdown()
- * }}}
- *
- * Any unhandled exceptions will cause the underlying Kafka consumer to be re-started after
- * the specified `simple-consumer.restart-on-exception-delay` interval plus a random offset.
- *
- * @param topic  The Kafka topic to connect to
- * @param kafkaConsumerProps Standard Kafka client Properties. It should contain "bootstrap.server"
- *                           and "consumer.group" as a minimum.
- * @param keyDeserializer Optional key deserializer, by default String-based
- * @param valueDeserializer Optional value deserializer, by default String-based
- * @param pollTimeout Optional timeout for the Kafka client poll() call
- * @param restartOnExceptionDelay Optional sleep time before reconnecting on an exception
- * @tparam K
- * @tparam V
- */
+  * SimpleKafkaConsumer aims to abstract away low level Kafka polling and error handling details.
+  *
+  * All you have to do is extend this class and provide your own implementation of
+  * `processRecords(...)` method:
+  * {{{
+  * import scala.collection.JavaConversions._
+  *
+  * class MyConsumer extends SimpleKafkaConsumer(
+  *   myTopic, properties)
+  * {
+  *   override protected def processRecords(records: ConsumerRecords[String, String]): Unit = {
+  *     for (record <- records) { println(record) }
+  *   }
+  * }
+  * }}}
+  *
+  * After instantiation, call the `start()` to begin polling the configured Kafka broker.
+  * Remember to call the `shutdown()` method in order to stop polling and release all the
+  * assigned partitions.
+  *
+  * {{{
+  *   val consumer = new MyConsumer
+  *   consumer.start()
+  *   ...
+  *   consumer.shutdown()
+  * }}}
+  *
+  * Any unhandled exceptions will cause the underlying Kafka consumer to be re-started after
+  * the specified `simple-consumer.restart-on-exception-delay` interval plus a random offset.
+  *
+  * @param topic  The Kafka topic to connect to
+  * @param kafkaConsumerProps Standard Kafka client Properties. It should contain "bootstrap.server"
+  *                           and "consumer.group" as a minimum.
+  * @param keyDeserializer Optional key deserializer, by default String-based
+  * @param valueDeserializer Optional value deserializer, by default String-based
+  * @param pollTimeout Optional timeout for the Kafka client poll() call
+  * @param restartOnExceptionDelay Optional sleep time before reconnecting on an exception
+  * @tparam K
+  * @tparam V
+  */
 abstract class SimpleKafkaConsumer[K, V](
     val topic: String,
     val kafkaConsumerProps: Properties,
@@ -62,8 +62,7 @@ abstract class SimpleKafkaConsumer[K, V](
     val pollTimeout: Duration = SimpleKafkaConsumer.pollTimeout,
     val restartOnExceptionDelay: Duration = SimpleKafkaConsumer.restartOnExceptionDelay,
     val commitOffsetTimeout: Duration = SimpleKafkaConsumer.commitOffsetTimeout,
-    val metrics: ConsumerMetrics = SimpleConsumerMetrics
-) {
+    val metrics: ConsumerMetrics = SimpleConsumerMetrics) {
   protected val log = LoggerFactory.getLogger(this.getClass)
 
   private val lock = new Object
@@ -74,30 +73,30 @@ abstract class SimpleKafkaConsumer[K, V](
   @volatile private var isPollingThreadRunning = false
 
   /**
-   * Calculates how long `onPartitionRevoked()` should block for to avoid split brain scenarios.
-   *
-   * @param maxMessageProcessingDuration maximum time allowance to process messages before
-   *                                     an exception is thrown
-   * @return
-   */
+    * Calculates how long `onPartitionRevoked()` should block for to avoid split brain scenarios.
+    *
+    * @param maxMessageProcessingDuration maximum time allowance to process messages before
+    *                                     an exception is thrown
+    * @return
+    */
   protected def minIsolationDetectionDuration(maxMessageProcessingDuration: Duration): Duration = {
     pollTimeout + maxMessageProcessingDuration + commitOffsetTimeout
   }
 
   /**
-   * SimpleKafkaConsumer is considered to be `terminated` after `shutdown()` has been called
-   * and the polling thread has stopped.
-   *
-   * @return true when the polling thread has stopped after a call to `shutdown()`
-   */
+    * SimpleKafkaConsumer is considered to be `terminated` after `shutdown()` has been called
+    * and the polling thread has stopped.
+    *
+    * @return true when the polling thread has stopped after a call to `shutdown()`
+    */
   final def hasTerminated = shutdownRequested && !isPollingThreadRunning
 
   /**
-   * Starts the polling thread. Once started, the consumer must be `shutdown()` to terminate.
-   *
-   * Any unhandled exceptions will cause the underlying Kafka consumer to be re-started after
-   * the specified `restart-on-exception-delay` interval plus a random offset.
-   */
+    * Starts the polling thread. Once started, the consumer must be `shutdown()` to terminate.
+    *
+    * Any unhandled exceptions will cause the underlying Kafka consumer to be re-started after
+    * the specified `restart-on-exception-delay` interval plus a random offset.
+    */
   final def start(): Unit = lock.synchronized {
     if (isPollingThreadRunning) throw new IllegalStateException("Already running.")
     if (shutdownPromise.isCompleted) throw new IllegalStateException("Was shutdown.")
@@ -121,10 +120,10 @@ abstract class SimpleKafkaConsumer[K, V](
   }
 
   /**
-   * Will cause the polling thread to shutdown.
-   *
-   * @return a future that will becomes complete when shutdown is finished
-   */
+    * Will cause the polling thread to shutdown.
+    *
+    * @return a future that will becomes complete when shutdown is finished
+    */
   def shutdown(): Future[Unit] = lock.synchronized {
     shutdownRequested = true
     currentKafkaConsumer.foreach(_.wakeup())
@@ -133,52 +132,52 @@ abstract class SimpleKafkaConsumer[K, V](
   }
 
   /**
-   * Get the number of partitions for the kafka topic.
-   *
-   * This intentionally does NOT fetch the value fresh when this method is called but uses a
-   * cached value that is fetched once every time the polling thread connects or reconnects
-   * to the underlying consumer.
-   *
-   * This means that if the polling thread has not yet started or the first connect has not
-   * yet succeeded, this will return None.
-   *
-   * This also means that the number of partitions returned here may be out of date if the
-   * number of partitions on Kafka is changed. Because of this, any service using this
-   * should be restarted to handle a change in the number of partitions.
-   */
+    * Get the number of partitions for the kafka topic.
+    *
+    * This intentionally does NOT fetch the value fresh when this method is called but uses a
+    * cached value that is fetched once every time the polling thread connects or reconnects
+    * to the underlying consumer.
+    *
+    * This means that if the polling thread has not yet started or the first connect has not
+    * yet succeeded, this will return None.
+    *
+    * This also means that the number of partitions returned here may be out of date if the
+    * number of partitions on Kafka is changed. Because of this, any service using this
+    * should be restarted to handle a change in the number of partitions.
+    */
   def partitionCount: Option[Int] = {
     currentPartitionCount
   }
 
   /**
-   * This is the only method you need to implement in order to start consuming messages using
-   * SimpleKafkaConsumer. The consumer offset is committed after every successful invocation
-   * of this method. If this method throws and exception, all of the records in the failed
-   * batch will be eventually retried.
-   *
-   * Any unhandled exceptions will cause the underlying Kafka consumer to be re-started after
-   * the specified `restart-on-exception-delay` interval plus a random offset.
-   *
-   * To prevent auto-restart, you may be tempted to explicitly call `shutdown()` from inside your
-   * exception handler. However, doing this will shutdown the SimpleKafkaConsumer permanently,
-   * leaving your application in a degraded state.
-   *
-   * @param records result of polling Kafka, may be empty
-   */
+    * This is the only method you need to implement in order to start consuming messages using
+    * SimpleKafkaConsumer. The consumer offset is committed after every successful invocation
+    * of this method. If this method throws and exception, all of the records in the failed
+    * batch will be eventually retried.
+    *
+    * Any unhandled exceptions will cause the underlying Kafka consumer to be re-started after
+    * the specified `restart-on-exception-delay` interval plus a random offset.
+    *
+    * To prevent auto-restart, you may be tempted to explicitly call `shutdown()` from inside your
+    * exception handler. However, doing this will shutdown the SimpleKafkaConsumer permanently,
+    * leaving your application in a degraded state.
+    *
+    * @param records result of polling Kafka, may be empty
+    */
   protected def processRecords(records: ConsumerRecords[K, V]): Unit
 
   /**
-   * Shutdown any custom resources.
-   */
+    * Shutdown any custom resources.
+    */
   protected def shutdownResources(): Unit = {}
 
   /**
-   * Allows to inject custom ConsumerRebalanceListener. The listener code runs on the polling
-   * thread, as described in
-   * [[http://kafka.apache.org/090/javadoc/org/apache/kafka/clients/consumer/ConsumerRebalanceListener.html Kafka documentation]]
-   *
-   * @return an instance of ConsumerRebalanceListener
-   */
+    * Allows to inject custom ConsumerRebalanceListener. The listener code runs on the polling
+    * thread, as described in
+    * [[http://kafka.apache.org/090/javadoc/org/apache/kafka/clients/consumer/ConsumerRebalanceListener.html Kafka documentation]]
+    *
+    * @return an instance of ConsumerRebalanceListener
+    */
   protected def makeRebalanceListener(): ConsumerRebalanceListener = {
     new LoggingRebalanceListener(topic, log) {
       override protected def logNewAssignment(partitions: Set[TopicPartition]): Unit = {
@@ -276,8 +275,11 @@ abstract class SimpleKafkaConsumer[K, V](
   private def logExceptionAndDelayRestart(exception: Throwable): Unit = {
     val randomDelay = Random.nextInt(restartOnExceptionDelay.toSeconds.toInt).seconds
     val restartDelayWithRandomOffset = restartOnExceptionDelay + randomDelay
-    log.error("Unhandled exception, restarting kafka consumer " +
-      s"in $restartDelayWithRandomOffset.", exception)
+    log.error(
+      "Unhandled exception, restarting kafka consumer " +
+        s"in $restartDelayWithRandomOffset.",
+      exception
+    )
     setCurrentThreadDescription("awaiting restart")
     sleepWithInterrupt(restartDelayWithRandomOffset)
   }
@@ -314,19 +316,18 @@ abstract class SimpleKafkaConsumer[K, V](
 }
 
 object SimpleKafkaConsumer {
+
   /** Default poll timeout */
   val pollTimeout: Duration = 1 second
+
   /** Default restart delay */
   val restartOnExceptionDelay: Duration = 5 seconds
+
   /** Default commit offset timeout */
   val commitOffsetTimeout: Duration = 5 seconds
 
   /** Helper to create basic properties */
-  def makeProps(
-    bootstrapServer: String,
-    consumerGroup: String,
-    maxPollRecords: Option[Int] = None
-  ): Properties = {
+  def makeProps(bootstrapServer: String, consumerGroup: String, maxPollRecords: Option[Int] = None): Properties = {
     val props = new Properties()
     props.put("group.id", consumerGroup)
     props.put("bootstrap.servers", bootstrapServer)
@@ -335,23 +336,25 @@ object SimpleKafkaConsumer {
     // usually a big "meh".
     props.put("max.partition.fetch.bytes", ((4 * 1024 * 1024) + 50000).toString)
 
-    maxPollRecords.foreach { (v: Int) => props.put("max.poll.records", v.toString) }
+    maxPollRecords.foreach { (v: Int) =>
+      props.put("max.poll.records", v.toString)
+    }
 
     props
   }
 }
 
 /**
- * A metrics sink for KafkaConsumer. Provide an implementation that calls the given method]
- * or leave the dummy version to not collect metrics.
- */
+  * A metrics sink for KafkaConsumer. Provide an implementation that calls the given method]
+  * or leave the dummy version to not collect metrics.
+  */
 trait ConsumerMetrics {
   def timeCommitSync(f: => Unit): Unit
 }
 
 /**
- * Metrics implementation that does no actual timing metric.
- */
+  * Metrics implementation that does no actual timing metric.
+  */
 object SimpleConsumerMetrics extends ConsumerMetrics {
 
   override def timeCommitSync(f: => Unit): Unit = { f }

--- a/partitioned/src/main/scala/com/pagerduty/kafkaconsumer/PartitionedKafkaConsumer.scala
+++ b/partitioned/src/main/scala/com/pagerduty/kafkaconsumer/PartitionedKafkaConsumer.scala
@@ -1,0 +1,254 @@
+package com.pagerduty.kafkaconsumer
+
+import akka.Done
+import akka.actor.{ ActorSystem, Cancellable }
+import akka.kafka.ConsumerMessage.CommittableOffsetBatch
+import akka.kafka.scaladsl.Consumer
+import akka.kafka.{ AutoSubscription, ConsumerMessage, ConsumerSettings, Subscriptions }
+import akka.stream.{ ActorMaterializer, ActorMaterializerSettings, Supervision }
+import akka.stream.scaladsl.{ Keep, Sink, Source }
+import com.typesafe.config.{ Config, ConfigFactory }
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.serialization.Deserializer
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.{ Await, ExecutionContext, Future }
+import scala.concurrent.duration.{ Duration, FiniteDuration }
+import scala.util.{ Failure, Success }
+
+/**
+ * The PartitionedKafkaConsumer is an alternative to SimpleKafkaConsumer.
+ *
+ * The advantage it has is that partitions are consumed, processed, and committed independently from each other. So, a
+ * partition containing messages that take a long time to process will not slow down the processing of other partitions.
+ *
+ * Unlike SimpleKafkaConsumer, this consumer parallelizes the processing of messages from different partitions. This means
+ * there will also be greater throughput from this consumer since it can properly use multiple CPU cores.
+ *
+ * @param topic The topic from which to consume
+ * @param keyDeserializer The Kafka record key deserializer
+ * @param valueDeserializer The Kafka record value deserializer
+ * @param config Optional Typesafe config containing the `akka.kafka.consumer` config structure. This is used to tune the
+ *               underlying akka-stream-kafka library, and the Kafka client library.
+ *
+ *               See http://doc.akka.io/docs/akka-stream-kafka/current/consumer.html for details
+ * @param restartOnExceptionDelay How long to wait before restarting the consumer after an unhandled exception
+ * @param commitOffsetMaxBatchSize The maximum size of a batch of records before they are committed back to Kafka
+ * @param consumerShutdownTimeout Timeout on shutdown before the consumer is forcibly terminated
+ * @tparam K The type of the Kafka record key
+ * @tparam V The type of the Kafka record value
+ */
+abstract class PartitionedKafkaConsumer[K, V](
+    topic: String,
+    keyDeserializer: Deserializer[K],
+    valueDeserializer: Deserializer[V],
+    config: Config = ConfigFactory.load(),
+    restartOnExceptionDelay: FiniteDuration = PartitionedKafkaConsumer.RestartOnExceptionDelay,
+    commitOffsetMaxBatchSize: Long = PartitionedKafkaConsumer.CommitOffsetMaxBatchSize,
+    consumerShutdownTimeout: Duration = PartitionedKafkaConsumer.ConsumerShutdownTimeout
+) {
+
+  protected val log = LoggerFactory.getLogger(getClass)
+
+  private object Lock
+
+  @volatile private var optSystem: Option[ActorSystem] = None
+  @volatile private var optConsumer: Option[Consumer.Control] = None
+  @volatile private var optFutureConsumerStartup: Option[Cancellable] = None
+
+  private val decider: Supervision.Decider = { e =>
+    log.warn(s"Unhandled exception when consuming or processing Kafka message from topic $topic: ", e)
+    restartConsumer()
+    Supervision.Stop
+  }
+
+  def start(): Unit = Lock.synchronized {
+    if (optSystem.isDefined || optConsumer.isDefined)
+      throw new IllegalStateException("PartitionedKafkaConsumer has already been started!")
+
+    log.info(s"Starting PartitionedKafkaConsumer on topic: $topic...")
+
+    optSystem = Some(ActorSystem("PartitionedKafkaConsumer", config))
+
+    startConsumer()
+    log.info("PartitionedKafkaConsumer start-up is complete")
+  }
+
+  def shutdown(): Unit = Lock.synchronized {
+    log.info("Shutting down PartitionedKafkaConsumer...")
+    shutdownConsumer()
+    shutdownSystem()
+    log.info("PartitionedKafkaConsumer shutdown is complete")
+  }
+
+  /**
+   * This method is the only method that must be overridden to use this class.
+   *
+   * Logic to process an individual record from Kafka should be placed in this method. Once the method completes successfully,
+   * its offset will be committed asynchronously back to Kafka, subject to batching rules. Because of the batched and async commit,
+   * and because of the at-least-once characteristics of Kafka, this method should handle being called with the same record
+   * multiple times.
+   *
+   * If this method throws an exception, its offset will not be committed back to Kafka. Rather, the underlying Kafka
+   * consumer will be restarted after `restartOnExceptionDelay`. The same record will then be passed to this method.
+   * This allows for transient exceptions (e.g. network timeouts) to be handled gracefully. Non-transient exceptions,
+   * however, will cause this consumer to go into a restart loop, meaning that no records (even from other partitions)
+   * will be processed.
+   *
+   * This method should return a Future, completed when the record is processed. If your processing logic is synchronous,
+   * simply wrap it in a Future (probably with `blocking`) and let it be executed by a thread pool or other ExecutionContext.
+   * The point of this interface is to be flexible with respect to concurrency.
+   *
+   * @param record The Kafka record to process
+   * @param partition The partition from which the record was consumed
+   *
+   * @return A Future that, when complete, indicates that the record has been successfully processed
+   */
+  def processRecord(record: ConsumerRecord[K, V], partition: Int): Future[Unit]
+
+  /**
+   * This method can be overridden to hook in custom behaviour after a Kafka record has been successfully
+   * processed and committed.
+   *
+   * @param record The record for which an offset was committed
+   * @param partition The partition for which the offset was committed
+   * @param offset The offset which was committed
+   *
+   * @return A Future that, when complete, indicates that the custom logic has been completed
+   */
+  def afterCommit(record: ConsumerRecord[K, V], partition: Int, offset: Long): Future[Unit] = {
+    Future.successful(Unit)
+  }
+
+  private def startConsumer(): Unit = Lock.synchronized {
+    if (optConsumer.isDefined) {
+      throw new IllegalStateException("Can't start a consumer if one exists already!")
+    }
+
+    log.info("Starting Kafka consumer...")
+    implicit val system = optSystem.get
+    implicit val ec = system.dispatcher
+
+    val materializerSettings = ActorMaterializerSettings(system).withSupervisionStrategy(decider)
+    implicit val materializer = ActorMaterializer(materializerSettings)
+
+    val consumerSettings = ConsumerSettings(system, keyDeserializer, valueDeserializer)
+
+    val subscriptions = Subscriptions.topics(topic)
+
+    val (consumerControl, done) = buildConsumerSource(consumerSettings, subscriptions)
+      .toMat(Sink.ignore)(Keep.both)
+      .run()
+
+    optConsumer = Some(consumerControl)
+
+    done.onComplete {
+      case Success(_) => log.info("Kafka consumer is successfully shutdown")
+      case Failure(e) => log.warn(s"Kafka consumer has failed on topic $topic!", e)
+    }
+    log.info("Kafka consumer start-up is complete")
+  }
+
+  private def buildConsumerSource(
+    consumerSettings: ConsumerSettings[K, V],
+    subscriptions: AutoSubscription
+  )(implicit
+    executionContext: ExecutionContext,
+    materializer: ActorMaterializer): Source[Future[Done], Consumer.Control] = {
+    Consumer
+      .committablePartitionedSource(consumerSettings, subscriptions)
+      .map {
+        case (topicPartition, source) =>
+          val partition = topicPartition.partition()
+          source
+            .mapAsync(1) { msg =>
+              processRecord(msg.record, partition).map(_ => msg)
+            }
+            .batch(
+              max = commitOffsetMaxBatchSize,
+              first =>
+                (
+                  Seq(first),
+                  CommittableOffsetBatch.empty.updated(first.committableOffset)
+                )
+            ) {
+                case ((batchedRecords, batchedOffsets), elem) =>
+                  val r = batchedRecords :+ elem
+                  (r, batchedOffsets.updated(elem.committableOffset))
+              }
+            .mapAsync(1) {
+              case (batchedRecords, committableBatch) =>
+                committableBatch.commitScaladsl().map(_ => (batchedRecords, committableBatch))
+            }
+            .runForeach {
+              case (batchedRecords, offsetInfo) =>
+                batchedRecords.zip(offsetInfo.offsets) foreach {
+                  case (committedRecord, (_: ConsumerMessage.GroupTopicPartition, offset: Long)) =>
+                    afterCommit(committedRecord.record, partition, offset)
+                }
+            }
+
+      }
+  }
+
+  private def restartConsumer(): Unit = Lock.synchronized {
+    log.info("Restarting Kafka consumer...")
+
+    // the consumer might be shutdown already (through user-initiated shutdown), in which case this is a no-op
+    shutdownConsumer()
+
+    // it's possible that the system is already shutdown (through user-initiated shutdown)
+    // in this case, don't schedule the consumer startup
+    optSystem match {
+      case Some(system) =>
+        log.info(s"Scheduling Kafka consumer start-up for $restartOnExceptionDelay in the future")
+        optFutureConsumerStartup = Some(system.scheduler.scheduleOnce(restartOnExceptionDelay) {
+          startConsumer()
+          optFutureConsumerStartup = None
+        }(system.dispatcher))
+      case None =>
+        log.info("Not scheduling a Kafka consumer start-up because shutdown has been initiated")
+    }
+  }
+
+  private def shutdownConsumer() = Lock.synchronized {
+    optFutureConsumerStartup match {
+      case Some(futureConsumerStartup) =>
+        log.info("Cancelling scheduled Kafka consumer startup")
+        futureConsumerStartup.cancel()
+      case None => // nothing to do
+    }
+
+    optConsumer match {
+      case Some(consumer) =>
+        log.info("Shutting down Kafka consumer...")
+        Await.ready(consumer.shutdown(), consumerShutdownTimeout)
+        optConsumer = None
+        log.info("Kafka consumer shutdown complete")
+      case None =>
+        log.info("Skipping Kafka consumer shutdown, since it's already done")
+    }
+  }
+
+  private def shutdownSystem() = Lock.synchronized {
+    optSystem match {
+      case Some(system) =>
+        log.info("Shutting down underlying actor system...")
+        Await.ready(system.terminate(), PartitionedKafkaConsumer.SystemShutdownTimeout)
+        optSystem = None
+        log.info("Underlying actor system shutdown complete")
+      case None =>
+        log.info("Skipping underlying actor system shutdown, since it's already done")
+    }
+  }
+}
+
+object PartitionedKafkaConsumer {
+  import scala.concurrent.duration._
+
+  // Default values
+  val CommitOffsetMaxBatchSize = 20L
+  val ConsumerShutdownTimeout = 5.seconds
+  val SystemShutdownTimeout = 1.second
+  val RestartOnExceptionDelay = 5.seconds
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,4 @@ resolvers += Resolver.jcenterRepo
 
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
+addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.7")

--- a/test-support/src/main/scala/com/pagerduty/kafkaconsumer/testsupport/KafkaConsumerSpec.scala
+++ b/test-support/src/main/scala/com/pagerduty/kafkaconsumer/testsupport/KafkaConsumerSpec.scala
@@ -4,9 +4,9 @@ import org.scalatest._
 import org.slf4j.LoggerFactory
 
 /**
- * Extend this trait to create a Kafka integration test. See the integration test in
- * Datahose Reporting Consumer for an example.
- */
+  * Extend this trait to create a Kafka integration test. See the integration test in
+  * Datahose Reporting Consumer for an example.
+  */
 trait KafkaConsumerSpec extends BeforeAndAfterEachTestData with BeforeAndAfterAll { this: Suite =>
   protected val log = LoggerFactory.getLogger(this.getClass)
 

--- a/test-support/src/main/scala/com/pagerduty/kafkaconsumer/testsupport/TestConsumer.scala
+++ b/test-support/src/main/scala/com/pagerduty/kafkaconsumer/testsupport/TestConsumer.scala
@@ -26,11 +26,10 @@ object TestConsumerConfig {
 }
 
 class TestConsumer(
-  topic: String,
-  pollTimeout: Duration = 100 milliseconds,
-  restartOnExceptionDelay: Duration = SimpleKafkaConsumer.restartOnExceptionDelay,
-  maxPollRecords: Option[Int] = None
-)
+    topic: String,
+    pollTimeout: Duration = 100 milliseconds,
+    restartOnExceptionDelay: Duration = SimpleKafkaConsumer.restartOnExceptionDelay,
+    maxPollRecords: Option[Int] = None)
     extends SimpleKafkaConsumer(
       topic,
       TestConsumerConfig.makeProps(maxPollRecords),
@@ -97,10 +96,9 @@ trait ConsumerTestHelper { self: SimpleKafkaConsumer[_, _] =>
 }
 
 class ShutdownTestConsumer(
-  topic: String,
-  pollTimeout: Duration = 100 milliseconds,
-  restartOnExceptionDelay: Duration = SimpleKafkaConsumer.restartOnExceptionDelay
-)
+    topic: String,
+    pollTimeout: Duration = 100 milliseconds,
+    restartOnExceptionDelay: Duration = SimpleKafkaConsumer.restartOnExceptionDelay)
     extends SimpleKafkaConsumer(
       topic,
       TestConsumerConfig.makeProps(),

--- a/test-support/src/main/scala/com/pagerduty/kafkaconsumer/testsupport/TestProducer.scala
+++ b/test-support/src/main/scala/com/pagerduty/kafkaconsumer/testsupport/TestProducer.scala
@@ -1,7 +1,7 @@
 package com.pagerduty.kafkaconsumer.testsupport
 
 import java.util.Properties
-import org.apache.kafka.clients.producer.{ KafkaProducer, ProducerRecord }
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 import org.slf4j.LoggerFactory
 
 class TestProducer(val topic: String) {

--- a/tests/src/it/resources/application.conf
+++ b/tests/src/it/resources/application.conf
@@ -1,0 +1,14 @@
+akka = {
+  loggers = [
+    "akka.event.slf4j.Slf4jLogger"
+  ]
+  log-dead-letters = 0
+  log-dead-letters-during-shutdown = false
+
+  kafka.consumer {
+    kafka-clients {
+      bootstrap.servers = "localhost:9092"
+      group.id = "kafkaconsumer-it-consumer"
+    }
+  }
+}

--- a/tests/src/it/scala/com/pagerduty/kafkaconsumer/PartitionedKafkaConsumerSpec.scala
+++ b/tests/src/it/scala/com/pagerduty/kafkaconsumer/PartitionedKafkaConsumerSpec.scala
@@ -127,7 +127,7 @@ class PartitionedKafkaConsumerSpec extends FreeSpec with Matchers with KafkaCons
       override protected def processRecord(record: ConsumerRecord[String, String], partition: Int): Future[Unit] = {
         if (!hasFailedOnce) {
           hasFailedOnce = true
-          Future.failed(new RuntimeException("Simulated consumer exception."))
+          throw new RuntimeException("Simulated consumer exception.")
         } else {
           super.processRecord(record, partition)
         }

--- a/tests/src/it/scala/com/pagerduty/kafkaconsumer/PartitionedKafkaConsumerSpec.scala
+++ b/tests/src/it/scala/com/pagerduty/kafkaconsumer/PartitionedKafkaConsumerSpec.scala
@@ -1,0 +1,143 @@
+package com.pagerduty.kafkaconsumer
+
+import com.pagerduty.kafkaconsumer.testsupport.{KafkaConsumerSpec, TestProducer}
+import org.apache.kafka.clients.consumer.{ConsumerRecord}
+import org.scalatest.concurrent.Eventually
+import org.scalatest.{FreeSpec, Matchers}
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class PartitionedKafkaConsumerSpec extends FreeSpec with Matchers with KafkaConsumerSpec with Eventually {
+  protected val topic = "partitionedkafkaconsumer_it_topic"
+
+  object testProducer extends TestProducer(topic) {
+    def sendTestMessage(id: Long): Unit = {
+      val message = s"body_$id"
+      send(id.toString, message)
+
+    }
+    def sendTestMessages(ids: Seq[Long]): Unit = {
+      for (id <- ids) sendTestMessage(id)
+    }
+  }
+
+  "PartitionedKafkaConsumer should" - {
+    "throw an exception if started when already running" in {
+      val consumer = new TestConsumer
+      consumer.start()
+      an[IllegalStateException] should be thrownBy (consumer.start())
+      consumer.shutdown()
+    }
+
+    "process messages" in {
+      val consumer = new TestConsumer
+      consumer.start()
+
+      val ids = makeMessageIdSeq(10)
+      testProducer.sendTestMessages(ids)
+
+      eventually(timeout(25.seconds)) {
+        consumer.processedKeys shouldBe ids.toSet
+      }
+
+      consumer.shutdown()
+    }
+
+    "auto-restart on errors" in {
+      val failOnceConsumer = makeFailOnceConsumer(restartDelay = 1.second)
+      failOnceConsumer.start()
+
+      val ids = makeMessageIdSeq(10)
+      testProducer.sendTestMessages(ids)
+
+      eventually(timeout(25.seconds)) {
+        failOnceConsumer.processedKeys shouldBe ids.toSet
+      }
+
+      failOnceConsumer.shutdown()
+    }
+
+    "not commit until message processing is finished" in {
+      // `restartOnMessageConsumer` will poll some messages and then throw and exception.
+      // The consumer offset should not be advanced, so these messages can be consumed later.
+      val restartOnMessageConsumer = makeFailingConsumer()
+      restartOnMessageConsumer.start()
+
+      val ids = makeMessageIdSeq(10)
+      testProducer.sendTestMessages(ids)
+
+      val consumer = new TestConsumer
+      consumer.start()
+      eventually(timeout(25.seconds)) {
+        consumer.processedKeys shouldBe ids.toSet
+      }
+      consumer.shutdown()
+      restartOnMessageConsumer.shutdown()
+    }
+
+    "shutdown quickly when waiting to restart" in {
+      val restartOnMessageConsumer = makeFailingConsumer()
+      restartOnMessageConsumer.start()
+
+      testProducer.sendTestMessage(id = 1)
+      val waitForConsumerToFail = 1.second
+      Thread.sleep(waitForConsumerToFail.toMillis)
+      // At this stage, consumer should be waiting to restart
+      val shutdown = Future {
+        restartOnMessageConsumer.shutdown()
+      }
+
+      Await.ready(shutdown, 5.seconds)
+    }
+  }
+
+  class TestConsumer(restartDelay: FiniteDuration = 5.seconds)
+      extends PartitionedKafkaConsumer(
+        topic = topic,
+        restartOnExceptionDelay = restartDelay
+      ) {
+    protected def processRecord(record: ConsumerRecord[String, String], partition: Int): Future[Unit] = {
+      Future {
+        recordKey(record.key())
+      }
+    }
+
+    @volatile private var keys = Set.empty[Long]
+    def processedKeys: Set[Long] = this.synchronized { keys }
+    private def recordKey(key: String) = this.synchronized {
+      try {
+        keys += key.toLong
+      } catch {
+        case _: NumberFormatException => // ignore
+      }
+    }
+  }
+
+  def makeMessageIdSeq(count: Int): Seq[Long] = {
+    val timeStamp = System.currentTimeMillis
+    timeStamp.until(timeStamp + count)
+  }
+
+  def makeFailOnceConsumer(restartDelay: FiniteDuration): TestConsumer =
+    new TestConsumer(restartDelay) {
+      private var hasFailedOnce = false
+
+      override protected def processRecord(record: ConsumerRecord[String, String], partition: Int): Future[Unit] = {
+        if (!hasFailedOnce) {
+          hasFailedOnce = true
+          Future.failed(new RuntimeException("Simulated consumer exception."))
+        } else {
+          super.processRecord(record, partition)
+        }
+      }
+    }
+
+  def makeFailingConsumer(): TestConsumer =
+    new TestConsumer(20 second) {
+      override protected def processRecord(record: ConsumerRecord[String, String], partition: Int): Future[Unit] = {
+        throw new RuntimeException("Simulated consumer exception.")
+      }
+    }
+}

--- a/tests/src/it/scala/com/pagerduty/kafkaconsumer/SimpleKafkaConsumerSpec.scala
+++ b/tests/src/it/scala/com/pagerduty/kafkaconsumer/SimpleKafkaConsumerSpec.scala
@@ -8,9 +8,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class SimpleKafkaConsumerSpec
-  extends FreeSpec with Matchers with KafkaConsumerSpec with Eventually
-{
+class SimpleKafkaConsumerSpec extends FreeSpec with Matchers with KafkaConsumerSpec with Eventually {
   protected val topic = "kafkaconsumer_it_topic"
 
   object testProducer extends TestProducer(topic) {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.1"
+version in ThisBuild := "0.5.0-DVGSNAP1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.0-DVGSNAP1"
+version in ThisBuild := "0.5.0"


### PR DESCRIPTION
Code is complete, and (no longer) lacking:

- [x] tests
- [x] docs

Usage example in https://github.com/PagerDuty/akka-streams-kafka-consumer/blob/master/src/main/scala/com/pagerduty/akkastreamskafkaconsumer/MessageConsumer.scala

This PR also adds scalafmt, so there's a bit of noise unfortunately.

Because `PartitionedKafkaConsumer` uses Akka Streams, it will only be available for 2.11 and 2.12, not 2.10. I had to do some Travis shenanigans to make this work. While I was at it, I cross-compiled the other artifacts for 2.12 as well.