### PR TITLE
Enforce an upperbound on number of restarts due to exceptions within a time interval

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,6 +54,7 @@ lazy val tests = (project in file("tests"))
   .settings(Defaults.itSettings: _*)
   .settings(sharedSettings: _*)
   .settings(
+    scalaVersion := "2.12.2",
     name := "kafka-consumer-tests",
     publishArtifact in Compile := false,
     publishArtifact in Test := false,
@@ -74,6 +75,7 @@ lazy val testSupport = (project in file("test-support"))
   .settings(sharedSettings: _*)
   .settings(publishSettings: _*)
   .settings(
+    scalaVersion := "2.12.2",
     name := "kafka-consumer-test-support",
     crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.2"),
     libraryDependencies ++= Seq(
@@ -117,3 +119,5 @@ lazy val root = (project in file("."))
     publishArtifact := false
   )
   .aggregate(tests, testSupport, main, partitioned)
+
+cancelable in Global := true

--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ lazy val KafkaClientVersion = "0.10.1.1"
 
 lazy val sharedSettings = Seq(
   organization := "com.pagerduty",
-  scalaVersion := "2.11.11",
+  scalaVersion := "2.12.2",
   // akka-stream-kafka wants a newer version, but works fine with the older client
   dependencyOverrides += "org.apache.kafka" % "kafka-clients" % KafkaClientVersion,
   scalafmtTestOnCompile := true
@@ -54,7 +54,6 @@ lazy val tests = (project in file("tests"))
   .settings(Defaults.itSettings: _*)
   .settings(sharedSettings: _*)
   .settings(
-    scalaVersion := "2.12.2",
     name := "kafka-consumer-tests",
     publishArtifact in Compile := false,
     publishArtifact in Test := false,
@@ -75,7 +74,6 @@ lazy val testSupport = (project in file("test-support"))
   .settings(sharedSettings: _*)
   .settings(publishSettings: _*)
   .settings(
-    scalaVersion := "2.12.2",
     name := "kafka-consumer-test-support",
     crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.2"),
     libraryDependencies ++= Seq(

--- a/test-support/src/main/scala/com/pagerduty/kafkaconsumer/testsupport/TestConsumer.scala
+++ b/test-support/src/main/scala/com/pagerduty/kafkaconsumer/testsupport/TestConsumer.scala
@@ -98,12 +98,16 @@ trait ConsumerTestHelper { self: SimpleKafkaConsumer[_, _] =>
 class ShutdownTestConsumer(
     topic: String,
     pollTimeout: Duration = 100 milliseconds,
-    restartOnExceptionDelay: Duration = SimpleKafkaConsumer.restartOnExceptionDelay)
+    restartOnExceptionDelay: Duration = SimpleKafkaConsumer.restartOnExceptionDelay,
+    maxRestartsInIntervalDueToExceptions: Int = SimpleKafkaConsumer.maxRestartsInIntervalDueToExceptions,
+    restartDueToExceptionsInterval: Duration = SimpleKafkaConsumer.restartDueToExceptionsInterval)
     extends SimpleKafkaConsumer(
       topic,
       TestConsumerConfig.makeProps(),
       pollTimeout = pollTimeout,
-      restartOnExceptionDelay = restartOnExceptionDelay
+      restartOnExceptionDelay = restartOnExceptionDelay,
+      maxRestartsInIntervalDueToExceptions = maxRestartsInIntervalDueToExceptions,
+      restartDueToExceptionsInterval = restartDueToExceptionsInterval
     ) {
   override protected def processRecords(records: ConsumerRecords[String, String]): Unit = {}
 

--- a/tests/src/it/scala/com/pagerduty/kafkaconsumer/SimpleKafkaConsumerSpec.scala
+++ b/tests/src/it/scala/com/pagerduty/kafkaconsumer/SimpleKafkaConsumerSpec.scala
@@ -124,7 +124,7 @@ class SimpleKafkaConsumerSpec extends FreeSpec with Matchers with KafkaConsumerS
     }
 
     "support max.poll.records" in {
-      val consumer = new TestConsumer(topic, maxPollRecords = Option(4))
+      val consumer = new TestConsumer(topic, pollTimeout = 10.seconds, maxPollRecords = Option(4))
       consumer.start()
 
       val ids: Seq[Long] = makeMessageIdSeq(10)

--- a/tests/src/it/scala/com/pagerduty/kafkaconsumer/SimpleKafkaConsumerSpec.scala
+++ b/tests/src/it/scala/com/pagerduty/kafkaconsumer/SimpleKafkaConsumerSpec.scala
@@ -135,6 +135,20 @@ class SimpleKafkaConsumerSpec extends FreeSpec with Matchers with KafkaConsumerS
       val expectedIdGroups: Seq[Seq[Long]] = ids.grouped(4).toSeq
       consumer.processedKeyGroups shouldBe expectedIdGroups
     }
+
+    "After to many exceptions in a short time period, the consumer dies" in {
+      val restartDelay = 1.second
+      val restarts = 2
+      val badConsumer = makeFailingConsumer(restartDelay = restartDelay, maxRestarts = restarts, restartInterval = 100 minutes)
+      badConsumer.start()
+
+      val ids: Seq[Long] = makeMessageIdSeq(10)
+      testProducer.sendTestMessages(ids)
+
+      val delay = badConsumer.awaitTerminationAndTrackDelay()
+
+      delay should be < (restartDelay * restarts + 10.second /* 10s buffer */).toMillis
+    }
   }
 
   def makeMessageIdSeq(count: Int): Seq[Long] = {
@@ -167,8 +181,8 @@ class SimpleKafkaConsumerSpec extends FreeSpec with Matchers with KafkaConsumerS
   def makeConsumer(pollTimeout: Duration): ShutdownTestConsumer =
     new ShutdownTestConsumer(topic, pollTimeout = pollTimeout)
 
-  def makeFailingConsumer(restartDelay: Duration): ShutdownTestConsumer =
-    new ShutdownTestConsumer(topic, restartOnExceptionDelay = restartDelay) {
+  def makeFailingConsumer(restartDelay: Duration, maxRestarts: Int = SimpleKafkaConsumer.maxRestartsInIntervalDueToExceptions, restartInterval: Duration = SimpleKafkaConsumer.restartDueToExceptionsInterval): ShutdownTestConsumer =
+    new ShutdownTestConsumer(topic, restartOnExceptionDelay = restartDelay, maxRestartsInIntervalDueToExceptions = maxRestarts, restartDueToExceptionsInterval = restartInterval) {
       override protected def processRecords(records: ConsumerRecords[String, String]): Unit = {
         throw new RuntimeException("Simulated consumer exception.")
       }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.0"
+version in ThisBuild := "0.6.0"


### PR DESCRIPTION
SimpleKafkaConsumer will now terminate if it restarts too often due to unhandled exceptions in some time interval.

Users of the library can detect these error cases by passing in a handler. This handler will be called when the consumer dies due to unhandled exceptions.